### PR TITLE
Allows for semantic versionsing of vars

### DIFF
--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -37,7 +37,7 @@ var (
 	cmdGet        = app.Command("get", "Get a credential from the store.")
 	cmdGetName    = cmdGet.Arg("credential", "The name of the credential to get.").Required().String()
 	cmdGetNoLine  = cmdGet.Flag("noline", "Leave off the newline when emitting secret").Short('n').Bool()
-	cmdGetVersion = cmdGet.Arg("version", "The version of the credential to get.").Int()
+	cmdGetVersion = cmdGet.Arg("version", "The version of the credential to get.").Default("").String()
 
 	cmdGetAll         = app.Command("getall", "Get latest credentials from the store.")
 	cmdGetAllVersions = cmdGetAll.Flag("all", "List all versions").Bool()
@@ -48,12 +48,12 @@ var (
 	cmdPut        = app.Command("put", "Put a credential into the store.")
 	cmdPutName    = cmdPut.Arg("credential", "The name of the credential to store.").Required().String()
 	cmdPutSecret  = cmdPut.Arg("value", "The value of the credential to store.").Required().String()
-	cmdPutVersion = cmdPut.Arg("version", "Version to store with the credential.").Int()
+	cmdPutVersion = cmdPut.Arg("version", "Version to store with the credential.").Default("").String()
 
 	cmdPutFile           = app.Command("put-file", "Put a credential from a file into the store.")
 	cmdPutFileName       = cmdPutFile.Arg("credential", "The name of the credential to store.").Required().String()
 	cmdPutFileSecretPath = cmdPutFile.Arg("value", "Path to file containing the credential to store.").Required().String()
-	cmdPutFileVersion    = cmdPutFile.Arg("version", "Version to store with the credential.").Int()
+	cmdPutFileVersion    = cmdPutFile.Arg("version", "Version to store with the credential.").Default("").String()
 
 	cmdDelete     = app.Command("delete", "Delete a credential from the store.")
 	cmdDeleteName = cmdDelete.Arg("credential", "The name of the credential to delete.").Required().String()
@@ -92,10 +92,10 @@ func main() {
 	case cmdGet.FullCommand():
 		var cred *unicreds.DecryptedCredential
 		var err error
-		if *cmdGetVersion == 0 {
+		if *cmdGetVersion == "" {
 			cred, err = unicreds.GetHighestVersionSecret(dynamoTable, *cmdGetName, encContext)
 		} else {
-			cred, err = unicreds.GetSecret(dynamoTable, *cmdGetName, unicreds.PaddedInt(*cmdGetVersion), encContext)
+			cred, err = unicreds.GetSecret(dynamoTable, *cmdGetName, unicreds.PaddedVersion(*cmdGetVersion), encContext)
 		}
 		if err != nil {
 			printFatalError(err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/apex/log"
@@ -42,7 +43,7 @@ func TestIntegrationGetSecret(t *testing.T) {
 	(*encContext)["test"] = aws.String("123")
 
 	for i := 0; i < 15; i++ {
-		err = unicreds.PutSecret(aws.String(tableName), alias, "Integration1", fmt.Sprintf("secret%d", i), unicreds.PaddedInt(i), encContext)
+		err = unicreds.PutSecret(aws.String(tableName), alias, "Integration1", fmt.Sprintf("secret%d", i), unicreds.PaddedVersion(strconv.Itoa(i)), encContext)
 		if err != nil {
 			log.Errorf("put err: %v", err)
 		}
@@ -58,12 +59,12 @@ func TestIntegrationGetSecret(t *testing.T) {
 	assert.NotZero(t, cred.Version)
 
 	for i := 0; i < 15; i++ {
-		cred, err := unicreds.GetSecret(aws.String(tableName), "Integration1", unicreds.PaddedInt(i), encContext)
+		cred, err := unicreds.GetSecret(aws.String(tableName), "Integration1", unicreds.PaddedVersion(strconv.Itoa(i)), encContext)
 		assert.Nil(t, err)
 		assert.Equal(t, cred.Name, "Integration1")
 		assert.Equal(t, cred.Secret, fmt.Sprintf("secret%d", i))
 		assert.NotZero(t, cred.CreatedAt)
-		assert.Equal(t, cred.Version, unicreds.PaddedInt(i))
+		assert.Equal(t, cred.Version, unicreds.PaddedVersion(strconv.Itoa(i)))
 	}
 
 	creds, err := unicreds.GetAllSecrets(aws.String(tableName), true)


### PR DESCRIPTION
Updates the version handle of variables so they can be strings,
this allows for semantic versions to be used. This mimics the
behaviour of the original Credstash where versions are not
limited to integers only, whether by design or by nature of
Python's dynamic type system.

This feature does have some negative sides; however these
are present in the original Credstash so this a like for like
port:

* Sorting is broken if integers and strings are mixed together
for the same variable; however if a variable is only ever
versioned with a string then ordering works, same for integers
* Auto-increment with string based versions doesn't quite work

If the choice is made to use Semantic Versioning with variables
then essentially the version must always be specified when
adding a new value, however if you are using SemVer then this
should always be the case.

The rationale behind this is so we can use real application
versions with variables, in the real world simple integers
are not used for application versioning and it doesn't make
sense to version an applications variables separately.